### PR TITLE
Improved process_add_components.

### DIFF
--- a/unittest/runtime.cpp
+++ b/unittest/runtime.cpp
@@ -36,12 +36,13 @@ TEST_CASE("The runtime interface") {
 			ecs.add_component({0, 9}, runtime_ctr_counter{});
 			ecs.commit_changes();
 
+			CHECK(ecs.get_component_count<runtime_ctr_counter>() == 10);
 			CHECK(runtime_ctr_counter::def_ctr_count == 1);
-			CHECK(runtime_ctr_counter::move_count == 2);
-			CHECK(runtime_ctr_counter::dtr_count == 3);
+			CHECK(runtime_ctr_counter::move_count == 1);
+			CHECK(runtime_ctr_counter::dtr_count == 2);
 			CHECK(runtime_ctr_counter::copy_count == 10);
 		}
-		CHECK(runtime_ctr_counter::dtr_count == 3 + 10);
+		CHECK(runtime_ctr_counter::dtr_count == 2 + 10);
 	}
 
 	SECTION("Allocates storage as needed") {


### PR DESCRIPTION
Removed a bunch of allocations and saved a move when adding components.

More than 12000% speedup in the particles benchmark.