### PR TITLE
Remove unsigned integers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,5 @@
 ---
-Checks:          '*,-altera-*,-cert-*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-modernize-use-trailing-return-type,-llvm-*,-llvmlibc*,-hicpp-braces-around-statements,-readability-magic-numbers,-cert-err58-cpp,-cppcoreguidelines-owning-memory,-readability-braces-around-statements,-bugprone-suspicious-semicolon'
+Checks:          '*,-altera-*,-cert-*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-modernize-use-trailing-return-type,-llvm-*,-llvmlibc*,-hicpp-braces-around-statements,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-readability-identifier-length,-cert-err58-cpp,-cppcoreguidelines-owning-memory,-readability-braces-around-statements,-bugprone-suspicious-semicolon'
 WarningsAsErrors: '1'
 HeaderFilterRegex: 'ecs\\include'
 FormatStyle:     none
-
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ if (MSVC)
         # enable lots of warnings
         /W4
 
+        # treat warnings as errors
+        /WX
+
         # -- Dump compilation info ---
         #/Bt                     # total time spent in frontend (d1) and backend (d2)
         #/d1templateStats        # show info regarding template use
@@ -38,8 +41,8 @@ if (MSVC)
         /w44800     # Implicit conversion from 'type' to bool. Possible information loss.
         /w44826     # Conversion from 'type1' to 'type2' is sign-extended. This may cause unexpected runtime behavior.
         /w45219     # implicit conversion from 'type-1' to 'type-2', possible loss of data.
-        #/w44388     # signed/unsigned mismatch
-        #/w44365     # 'action': conversion from 'type_1' to 'type_2', signed/unsigned mismatch.
+        /w44388     # signed/unsigned mismatch
+        /w44365     # 'action': conversion from 'type_1' to 'type_2', signed/unsigned mismatch.
 
 		# Shows the layout of the struct name 'chunk'
 		#/d1reportSingleClassLayoutchunk

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if (MSVC)
         /w44826     # Conversion from 'type1' to 'type2' is sign-extended. This may cause unexpected runtime behavior.
         /w45219     # implicit conversion from 'type-1' to 'type-2', possible loss of data.
         /w44388     # signed/unsigned mismatch
-        /w44365     # 'action': conversion from 'type_1' to 'type_2', signed/unsigned mismatch.
+        #/w44365     # 'action': conversion from 'type_1' to 'type_2', signed/unsigned mismatch.
 
 		# Shows the layout of the struct name 'chunk'
 		#/d1reportSingleClassLayoutchunk

--- a/include/ecs/detail/component_pool.h
+++ b/include/ecs/detail/component_pool.h
@@ -466,14 +466,15 @@ private:
 		// Offset into the chunks data
 		auto const ent_offset = c->range.offset(range.first());
 
-		for (auto const i : range) {
+		entity_id ent = range.first();
+		for (size_t i = 0; i < range.ucount(); ++i, ++ent) {
 			// Construct from a value or a a span of values
 			if constexpr (std::is_same_v<T, Data>) {
 				std::construct_at(&c->data[ent_offset + i], comp_data);
 			} else if constexpr (std::is_invocable_v<Data, entity_id>) {
-				std::construct_at(&c->data[ent_offset + i], comp_data(range.first() + i));
+				std::construct_at(&c->data[ent_offset + i], comp_data(ent));
 			} else {
-				std::construct_at(&c->data[ent_offset + i], comp_data[static_cast<std::size_t>(i)]);
+				std::construct_at(&c->data[ent_offset + i], comp_data[i]);
 			}
 		}
 	}

--- a/include/ecs/detail/component_pool.h
+++ b/include/ecs/detail/component_pool.h
@@ -231,18 +231,18 @@ public:
 	}
 
 	// Returns the number of active entities in the pool
-	constexpr size_t num_entities() const noexcept {
-		size_t count = 0;
+	constexpr ptrdiff_t num_entities() const noexcept {
+		ptrdiff_t count = 0;
 
 		for (entity_range const r : ordered_active_ranges) {
-			count += r.ucount();
+			count += r.count();
 		}
 
 		return count;
 	}
 
 	// Returns the number of active components in the pool
-	constexpr size_t num_components() const noexcept {
+	constexpr ptrdiff_t num_components() const noexcept {
 		if constexpr (unbound<T>)
 			return 1;
 		else

--- a/include/ecs/detail/component_pool.h
+++ b/include/ecs/detail/component_pool.h
@@ -435,15 +435,13 @@ private:
 	// Verify the 'add*' functions precondition.
 	// An entity can not have more than one of the same component
 	constexpr bool has_duplicate_entities() const noexcept {
-		if (!ordered_active_ranges.empty()) {
-			for (size_t i = 0; i < ordered_active_ranges.size() - 1; ++i) {
-				if (ordered_active_ranges[i].overlaps(ordered_active_ranges[i + 1]))
-					return true;
-			}
+		for (size_t i = 1; i < ordered_active_ranges.size(); ++i) {
+			if (ordered_active_ranges[i - 1].overlaps(ordered_active_ranges[i]))
+				return true;
 		}
 
 		return false;
-	};
+	}
 
 	constexpr static bool is_equal(T const& lhs, T const& rhs) noexcept requires std::equality_comparable<T> {
 		return lhs == rhs;

--- a/include/ecs/detail/component_pool.h
+++ b/include/ecs/detail/component_pool.h
@@ -134,7 +134,7 @@ public:
 	constexpr ~component_pool() noexcept override {
 		if constexpr (global<T>) {
 			std::destroy_at(head->data);
-			alloc.deallocate(head->data, head->range.count());
+			alloc.deallocate(head->data, head->range.ucount());
 			std::destroy_at(head);
 			alloc_chunk.deallocate(head, 1);
 		} else {

--- a/include/ecs/detail/component_pool.h
+++ b/include/ecs/detail/component_pool.h
@@ -250,8 +250,8 @@ public:
 	}
 
 	// Returns the number of chunks in use
-	constexpr size_t num_chunks() const noexcept {
-		return ordered_chunks.size();
+	constexpr ptrdiff_t num_chunks() const noexcept {
+		return std::ssize(ordered_chunks);
 	}
 
 	constexpr chunk const* get_head_chunk() const noexcept {
@@ -372,7 +372,7 @@ private:
 			} else {
 				if constexpr (!unbound<T>) {
 					std::destroy_n(c->data, c->active.ucount());
-					alloc.deallocate(c->data, c->range.count());
+					alloc.deallocate(c->data, c->range.ucount());
 				}
 			}
 		}
@@ -466,14 +466,14 @@ private:
 		// Offset into the chunks data
 		auto const ent_offset = c->range.offset(range.first());
 
-		for (entity_offset i = 0; i < range.ucount(); ++i) {
+		for (auto const i : range) {
 			// Construct from a value or a a span of values
 			if constexpr (std::is_same_v<T, Data>) {
 				std::construct_at(&c->data[ent_offset + i], comp_data);
 			} else if constexpr (std::is_invocable_v<Data, entity_id>) {
 				std::construct_at(&c->data[ent_offset + i], comp_data(range.first() + i));
 			} else {
-				std::construct_at(&c->data[ent_offset + i], comp_data[i]);
+				std::construct_at(&c->data[ent_offset + i], comp_data[static_cast<std::size_t>(i)]);
 			}
 		}
 	}

--- a/include/ecs/detail/entity_range_iterator.h
+++ b/include/ecs/detail/entity_range_iterator.h
@@ -68,7 +68,7 @@ public:
 		// Can't compare iterators from different sources
 		Expects(ranges.data() == other.ranges.data());
 
-		return current_range == other.current_range && range_it == other.range_it;
+		return current_range_index == other.current_range_index && range_it == other.range_it;
 	}
 
 	constexpr bool operator!=(entity_range_iterator other) const {
@@ -81,7 +81,7 @@ public:
 
 protected:
 	constexpr bool is_at_end() const {
-		return current_range == ranges.size();
+		return current_range_index == ranges.size();
 	}
 
 	// Step forward 'diff' entities.
@@ -97,28 +97,28 @@ protected:
 			auto remainder = diff - current_range_dist;
 
 			// Go to the next range
-			current_range += 1;
+			current_range_index += 1;
 
 			// If I have hit the end, this is now an end-iterator
-			if (current_range == ranges.size()) {
+			if (current_range_index == ranges.size()) {
 				return;
 			}
 
 			// Find the range
-			auto const count = static_cast<ptrdiff_t>(ranges[current_range].count());
+			auto const count = static_cast<ptrdiff_t>(ranges[current_range_index].count());
 			while (remainder >= count) {
 				// Update the remainder
 				remainder -= count;
 
-				current_range += 1;
-				if (current_range == ranges.size()) {
+				current_range_index += 1;
+				if (current_range_index == ranges.size()) {
 					return;
 				}
 			};
 
 			// Update the iterators
-			range_it = ranges[current_range].begin() + remainder;
-			range_end = ranges[current_range].end();
+			range_it = ranges[current_range_index].begin() + remainder;
+			range_end = ranges[current_range_index].end();
 		}
 	}
 
@@ -131,7 +131,7 @@ private:
 	entity_iterator range_end;
 
 	// The range currently being iterated
-	size_t current_range = 0;
+	size_t current_range_index = 0;
 };
 
 } // namespace ecs::detail

--- a/include/ecs/detail/system_hierachy.h
+++ b/include/ecs/detail/system_hierachy.h
@@ -104,7 +104,7 @@ private:
 		arguments.clear();
 		argument_spans.clear();
 
-		if (ranges.size() == 0) {
+		if (ranges.empty()) {
 			return;
 		}
 

--- a/include/ecs/runtime.h
+++ b/include/ecs/runtime.h
@@ -141,7 +141,7 @@ public:
 
 	// Returns the number of active components for a specific type of components
 	template <typename T>
-	size_t get_component_count() {
+	ptrdiff_t get_component_count() {
 		if (!ctx.has_component_pool<T>())
 			return 0;
 
@@ -152,7 +152,7 @@ public:
 
 	// Returns the number of entities that has the component.
 	template <typename T>
-	size_t get_entity_count() {
+	ptrdiff_t get_entity_count() {
 		if (!ctx.has_component_pool<T>())
 			return 0;
 

--- a/unittest/filtering.cpp
+++ b/unittest/filtering.cpp
@@ -32,7 +32,7 @@ TEST_CASE("Filtering", "[component][system]") {
 	});
 
 	// Filtering on non-existant component should run normally
-	std::atomic_size_t no_shorts = 0;
+	std::atomic_ptrdiff_t no_shorts = 0;
 	ecs.make_system([&no_shorts](int&, short*) { no_shorts++; });
 
 	ecs.run_systems();

--- a/unittest/global_component.cpp
+++ b/unittest/global_component.cpp
@@ -55,7 +55,7 @@ TEST_CASE("Global components", "[component][global]") {
 		ecs.commit_changes();
 
 		// Only 1 test_s should exist
-		CHECK(1 == ecs.get_component_count<test_s>());
+		CHECK(size_t{1} == ecs.get_component_count<test_s>());
 
 		// Test the content of the entities
 		ecs.run_systems();

--- a/unittest/hierarchy.cpp
+++ b/unittest/hierarchy.cpp
@@ -91,7 +91,7 @@ TEST_CASE("Hierarchies") {
 		ecs.update();
 
 		// Make sure all children where visited
-		CHECK(traversal_order.size() == (1 + ecs.get_component_count<ecs::detail::parent_id>()));
+		CHECK(std::ssize(traversal_order) == (1 + ecs.get_component_count<ecs::detail::parent_id>()));
 	}
 
 	SECTION("works on multiple trees") {
@@ -135,7 +135,7 @@ TEST_CASE("Hierarchies") {
 		ecs.update();
 
 		// Make sure all children where visited
-		CHECK(traversal_order.size() == (3 + ecs.get_component_count<ecs::detail::parent_id>()));
+		CHECK(std::ssize(traversal_order) == (3 + ecs.get_component_count<ecs::detail::parent_id>()));
 	}
 
 	SECTION("works on lots of trees") {
@@ -215,7 +215,7 @@ TEST_CASE("Hierarchies") {
 		ecs.update();
 
 		// Make sure all children where visited
-		CHECK(traversal_order.size() == (3 + ecs.get_component_count<ecs::detail::parent_id>()));
+		CHECK(std::ssize(traversal_order) == (3 + ecs.get_component_count<ecs::detail::parent_id>()));
 	}
 
 	SECTION("can be built bottoms-up") {
@@ -260,7 +260,7 @@ TEST_CASE("Hierarchies") {
 		ecs.update();
 
 		// Make sure all children where visited
-		CHECK(traversal_order.size() == (1 + ecs.get_component_count<ecs::detail::parent_id>()));
+		CHECK(std::ssize(traversal_order) == (1 + ecs.get_component_count<ecs::detail::parent_id>()));
 	}
 
 	SECTION("can be built in reverse") {
@@ -305,7 +305,7 @@ TEST_CASE("Hierarchies") {
 		ecs.update();
 
 		// Make sure all children where visited
-		CHECK(traversal_order.size() == (1 + ecs.get_component_count<ecs::detail::parent_id>()));
+		CHECK(std::ssize(traversal_order) == (1 + ecs.get_component_count<ecs::detail::parent_id>()));
 	}
 
 	SECTION("interactions with parents are correct") {

--- a/unittest/hierarchy.cpp
+++ b/unittest/hierarchy.cpp
@@ -171,7 +171,7 @@ TEST_CASE("Hierarchies") {
 		ecs.update();
 
 		// Make sure all children where visited
-		CHECK(traversal_order.size() == nentities);
+		CHECK(traversal_order.size() == size_t{nentities});
 	}
 
 	SECTION("works on multiple trees in parallel") {

--- a/unittest/runtime.cpp
+++ b/unittest/runtime.cpp
@@ -36,7 +36,7 @@ TEST_CASE("The runtime interface") {
 			ecs.add_component({0, 9}, runtime_ctr_counter{});
 			ecs.commit_changes();
 
-			CHECK(ecs.get_component_count<runtime_ctr_counter>() == 10);
+			CHECK(ecs.get_component_count<runtime_ctr_counter>() == size_t{10});
 			CHECK(runtime_ctr_counter::def_ctr_count == 1);
 			CHECK(runtime_ctr_counter::move_count == 1);
 			CHECK(runtime_ctr_counter::dtr_count == 2);

--- a/unittest/sorting.cpp
+++ b/unittest/sorting.cpp
@@ -9,40 +9,40 @@ TEST_CASE("Sorting") {
 	std::random_device rd;
 	std::mt19937 gen{rd()};
 
-	std::vector<int> ints(10);
+	std::vector<unsigned> ints(10);
 	std::iota(ints.begin(), ints.end(), 0);
 	std::shuffle(ints.begin(), ints.end(), gen);
 
 	ecs.add_component({0, 9}, ints);
 	ecs.commit_changes();
 
-	int test = std::numeric_limits<int>::min();
+	unsigned test = std::numeric_limits<unsigned>::min();
 	auto& asc = ecs.make_system<ecs::opts::not_parallel, ecs::opts::manual_update>(
-		[&test](int const& i) {
+		[&test](unsigned const& i) {
 			CHECK(test <= i);
 			test = i;
 		},
-		std::less<int>());
+		std::less<unsigned>());
 	asc.run();
 
-	test = std::numeric_limits<int>::max();
+	test = std::numeric_limits<unsigned>::max();
 	auto& dec = ecs.make_system<ecs::opts::not_parallel, ecs::opts::manual_update>(
-		[&test](int const& i) {
+		[&test](unsigned const& i) {
 			CHECK(test >= i);
 			test = i;
 		},
-		std::greater<int>());
+		std::greater<unsigned>());
 	dec.run();
 
 	// modify the components and re-check
-	auto& mod = ecs.make_system<ecs::opts::not_parallel, ecs::opts::manual_update>([&gen](int& i) {
+	auto& mod = ecs.make_system<ecs::opts::not_parallel, ecs::opts::manual_update>([&gen](unsigned& i) {
 		i = gen();
 	});
 	mod.run();
 
-	test = std::numeric_limits<int>::min();
+	test = std::numeric_limits<unsigned>::min();
 	asc.run();
 
-	test = std::numeric_limits<int>::max();
+	test = std::numeric_limits<unsigned>::max();
 	dec.run();
 }


### PR DESCRIPTION
Using unsigned integers for size and counts leads to errors. An expression like `-1 < vec.size() ` can never be true, because of the silent integer promotion that takes place.