### PR TITLE
Fixed instances of `ecs::runtime ecs;` in examples

### DIFF
--- a/examples/entt_example/entt_example.cpp
+++ b/examples/entt_example/entt_example.cpp
@@ -15,12 +15,12 @@ struct velocity {
 };
 
 int main() {
-	ecs::runtime ecs;
+	ecs::runtime rt;
 
-	ecs.make_system([](ecs::entity_id /*id*/, position& /*pos*/, velocity const& /*vel*/) { /* ... */ });
-	ecs.make_system([](velocity& /*vel*/) { /* ... */ });
+	rt.make_system([](ecs::entity_id /*id*/, position& /*pos*/, velocity const& /*vel*/) { /* ... */ });
+	rt.make_system([](velocity& /*vel*/) { /* ... */ });
 
-	ecs.add_component({0, 9}, position{}, velocity{});
+	rt.add_component({0, 9}, position{}, velocity{});
 
-	ecs.update();
+	rt.update();
 }

--- a/examples/example/example.cpp
+++ b/examples/example/example.cpp
@@ -7,14 +7,14 @@ struct greeting {
 };
 
 int main() {
-	ecs::runtime ecs;
+	ecs::runtime rt;
 
 	// The system
-	ecs.make_system([](greeting const& g) { std::cout << g.msg; });
+	rt.make_system([](greeting const& g) { std::cout << g.msg; });
 
 	// The entities
-	ecs.add_component({0, 2}, greeting{"alright "});
+	rt.add_component({0, 2}, greeting{"alright "});
 
 	// Run the system on all entities with a 'greeting' component
-	ecs.update();
+	rt.update();
 }

--- a/examples/filtering/filtering.cpp
+++ b/examples/filtering/filtering.cpp
@@ -2,21 +2,21 @@
 #include <iostream>
 
 int main() {
-	ecs::runtime ecs;
-	ecs.add_component({0, 6}, int());
-	ecs.add_component({3, 9}, float());
-	ecs.add_component({2, 3}, short());
-	ecs.commit_changes();
+	ecs::runtime rt;
+	rt.add_component({0, 6}, int());
+	rt.add_component({3, 9}, float());
+	rt.add_component({2, 3}, short());
+	rt.commit_changes();
 
 	using namespace ecs::opts;
-	auto &i = ecs.make_system<not_parallel, manual_update>([](ecs::entity_id id, int &) { std::cout << id << ' '; });
-	auto &f = ecs.make_system<not_parallel, manual_update>([](ecs::entity_id id, float &) { std::cout << id << ' '; });
-	auto &s = ecs.make_system<not_parallel, manual_update>([](ecs::entity_id id, short &) { std::cout << id << ' '; });
-	auto &i_no_f = ecs.make_system<not_parallel, manual_update>([](ecs::entity_id id, int &, float *) { std::cout << id << ' '; });
-	auto &f_no_i = ecs.make_system<not_parallel, manual_update>([](ecs::entity_id id, int *, float &) { std::cout << id << ' '; });
-	auto &i_f = ecs.make_system<not_parallel, manual_update>([](ecs::entity_id id, int &, float &) { std::cout << id << ' '; });
-	auto &i_no_s = ecs.make_system<not_parallel, manual_update>([](ecs::entity_id id, int &, short *) { std::cout << id << ' '; });
-	auto &i_no_f_s = ecs.make_system<not_parallel, manual_update>([](ecs::entity_id id, int &, float *, short *) { std::cout << id << ' '; });
+	auto &i = rt.make_system<not_parallel, manual_update>([](ecs::entity_id id, int &) { std::cout << id << ' '; });
+	auto &f = rt.make_system<not_parallel, manual_update>([](ecs::entity_id id, float &) { std::cout << id << ' '; });
+	auto &s = rt.make_system<not_parallel, manual_update>([](ecs::entity_id id, short &) { std::cout << id << ' '; });
+	auto &i_no_f = rt.make_system<not_parallel, manual_update>([](ecs::entity_id id, int &, float *) { std::cout << id << ' '; });
+	auto &f_no_i = rt.make_system<not_parallel, manual_update>([](ecs::entity_id id, int *, float &) { std::cout << id << ' '; });
+	auto &i_f = rt.make_system<not_parallel, manual_update>([](ecs::entity_id id, int &, float &) { std::cout << id << ' '; });
+	auto &i_no_s = rt.make_system<not_parallel, manual_update>([](ecs::entity_id id, int &, short *) { std::cout << id << ' '; });
+	auto &i_no_f_s = rt.make_system<not_parallel, manual_update>([](ecs::entity_id id, int &, float *, short *) { std::cout << id << ' '; });
 
 	std::cout << "ints:\n";
 	i.run();

--- a/examples/global_component/global_component.cpp
+++ b/examples/global_component/global_component.cpp
@@ -15,34 +15,34 @@ struct state_s {
 };
 
 int main() {
-	ecs::runtime ecs;
-	ecs.make_system([](A, state_s &state) {
+	ecs::runtime rt;
+	rt.make_system([](A, state_s &state) {
 		state.a++;
 		state.total++;
 	});
-	ecs.make_system([](B, state_s &state) {
+	rt.make_system([](B, state_s &state) {
 		state.b++;
 		state.total++;
 	});
-	ecs.make_system([](state_s const &global) {
+	rt.make_system([](state_s const &global) {
 		std::cout << "  state_s::a:     " << global.a << "\n";
 		std::cout << "  state_s::b:     " << global.b << "\n";
 		std::cout << "  state_s::total: " << global.total << "\n\n";
 	});
 
 	std::cout << "Adding 10 entities with an A component:\n";
-	ecs.add_component({0, 9}, A{});
+	rt.add_component({0, 9}, A{});
 
 	std::cout << "Adding 10 more entities with a B component:\n\n";
-	ecs.add_component({10, 19}, B{});
+	rt.add_component({10, 19}, B{});
 
-	ecs.update();
+	rt.update();
 
 	// Dump some stats
-	std::cout << "Number of entities with an A component:      " << ecs.get_entity_count<A>() << "\n";
-	std::cout << "Number of entities with a B component:       " << ecs.get_entity_count<B>() << "\n";
-	std::cout << "Number of entities with a state_s component: " << ecs.get_entity_count<state_s>() << "\n";
-	std::cout << "Number of A components allocated:            " << ecs.get_component_count<A>() << "\n";
-	std::cout << "Number of B components allocated:            " << ecs.get_component_count<B>() << "\n";
-	std::cout << "Number of state_s components allocated:      " << ecs.get_component_count<state_s>() << "\n";
+	std::cout << "Number of entities with an A component:      " << rt.get_entity_count<A>() << "\n";
+	std::cout << "Number of entities with a B component:       " << rt.get_entity_count<B>() << "\n";
+	std::cout << "Number of entities with a state_s component: " << rt.get_entity_count<state_s>() << "\n";
+	std::cout << "Number of A components allocated:            " << rt.get_component_count<A>() << "\n";
+	std::cout << "Number of B components allocated:            " << rt.get_component_count<B>() << "\n";
+	std::cout << "Number of state_s components allocated:      " << rt.get_component_count<state_s>() << "\n";
 }

--- a/examples/interval/interval.cpp
+++ b/examples/interval/interval.cpp
@@ -14,25 +14,25 @@ int main() {
 	std::array<int, num_intervals> counters;
 	counters.fill(0);
 
-	ecs::runtime ecs;
-	ecs.make_system<interval<intervals[0], 0>>([&counters](int const &) { ++counters[0]; });
-	ecs.make_system<interval<intervals[1], 0>>([&counters](int const &) { ++counters[1]; });
-	ecs.make_system<interval<intervals[2], 0>>([&counters](int const &) { ++counters[2]; });
-	ecs.make_system<interval<intervals[3], 0>>([&counters](int const &) { ++counters[3]; });
-	ecs.make_system<interval<intervals[4], 0>>([&counters](int const &) { ++counters[4]; });
-	ecs.make_system<interval<intervals[5], 0>>([&counters](int const &) { ++counters[5]; });
-	ecs.make_system<interval<intervals[6], 0>>([&counters](int const &) { ++counters[6]; });
-	ecs.make_system<interval<intervals[7], 0>>([&counters](int const &) { ++counters[7]; });
-	ecs.make_system<interval<0, intervals[8]>>([&counters](int const &) { ++counters[8]; });
-	ecs.make_system<interval<0, intervals[9]>>([&counters](int const &) { ++counters[9]; });
+	ecs::runtime rt;
+	rt.make_system<interval<intervals[0], 0>>([&counters](int const &) { ++counters[0]; });
+	rt.make_system<interval<intervals[1], 0>>([&counters](int const &) { ++counters[1]; });
+	rt.make_system<interval<intervals[2], 0>>([&counters](int const &) { ++counters[2]; });
+	rt.make_system<interval<intervals[3], 0>>([&counters](int const &) { ++counters[3]; });
+	rt.make_system<interval<intervals[4], 0>>([&counters](int const &) { ++counters[4]; });
+	rt.make_system<interval<intervals[5], 0>>([&counters](int const &) { ++counters[5]; });
+	rt.make_system<interval<intervals[6], 0>>([&counters](int const &) { ++counters[6]; });
+	rt.make_system<interval<intervals[7], 0>>([&counters](int const &) { ++counters[7]; });
+	rt.make_system<interval<0, intervals[8]>>([&counters](int const &) { ++counters[8]; });
+	rt.make_system<interval<0, intervals[9]>>([&counters](int const &) { ++counters[9]; });
 
-	ecs.add_component({0, 0}, int{});
-	ecs.commit_changes();
+	rt.add_component({0, 0}, int{});
+	rt.commit_changes();
 
 	// Run the systems for 1 second
 	auto const start = std::chrono::high_resolution_clock::now();
 	while (std::chrono::high_resolution_clock::now() - start <= 1s)
-		ecs.run_systems();
+		rt.run_systems();
 
 	for (size_t i = 0; i < num_intervals - 2; i++) {
 		std::cout << "System updated " << counters[i] << " times, maximum is " << 1'000 / intervals[i] << "\n";

--- a/examples/mandelbrot/mandelbrot.cpp
+++ b/examples/mandelbrot/mandelbrot.cpp
@@ -35,25 +35,25 @@ void mandelbrot_system(size_t& color, pos const& p) {
 }
 
 int main() {
-	ecs::runtime ecs;
+	ecs::runtime rt;
 	// Add the system
-	ecs.make_system(mandelbrot_system);
+	rt.make_system(mandelbrot_system);
 
 	// Add the size_t component to the pixels/entities
 	ecs::entity_range const ents{0, dimension * dimension - 1};
-	ecs.add_component(ents, size_t{0});
-	ecs.add_component_generator(ents, [](ecs::entity_id ent) -> pos {
+	rt.add_component(ents, size_t{0});
+	rt.add_component_generator(ents, [](ecs::entity_id ent) -> pos {
 		int const x = ent % dimension;
 		int const y = ent / dimension;
 		return {x, y};
 	});
 
 	// Commit all component changes and run the system
-	ecs.update();
+	rt.update();
 
 	// Count the pixels equal to one
 	size_t counter = 0;
-	for (size_t const& color : ecs.get_components<size_t>(ents))
+	for (size_t const& color : rt.get_components<size_t>(ents))
 		if (color == 1)
 			counter++;
 

--- a/examples/parallelism/parallelism.cpp
+++ b/examples/parallelism/parallelism.cpp
@@ -12,16 +12,16 @@ int main() {
 	using namespace ecs::opts;
 
 	// Make the systems
-	ecs::runtime ecs;
-	auto &serial_sys = ecs.make_system<not_parallel, manual_update>(sys_sleep);
-	auto &parallel_sys = ecs.make_system<manual_update>(sys_sleep);
+	ecs::runtime rt;
+	auto &serial_sys = rt.make_system<not_parallel, manual_update>(sys_sleep);
+	auto &parallel_sys = rt.make_system<manual_update>(sys_sleep);
 
 	// Create a range of entities that would
 	// take 5 seconds to process serially
-	ecs.add_component({0, 20 - 1}, short{0});
+	rt.add_component({0, 20 - 1}, short{0});
 
 	// Commit the components (does not run the systems)
-	ecs.commit_changes();
+	rt.commit_changes();
 
 	// Time the serial system
 	std::cout << "Running serial system: ";

--- a/examples/scheduler/scheduler.cpp
+++ b/examples/scheduler/scheduler.cpp
@@ -18,14 +18,14 @@ struct type {};
 
 int main() {
 	using namespace ecs::opts;
-	ecs::runtime ecs;
+	ecs::runtime rt;
 
 	std::cout << std::boolalpha;
 	std::cout << "creating systems:\n";
 
 	//
 	// Assumes that type 0 is writte to, and type 1 is only read from.
-	auto &sys1 = ecs.make_system<manual_update>([](type<0> &, type<1> const &) {
+	auto &sys1 = rt.make_system<manual_update>([](type<0> &, type<1> const &) {
 		std::cout << "1 ";
 		std::this_thread::sleep_for(20ms); // simulate work
 	});
@@ -34,7 +34,7 @@ int main() {
 	//
 	// Writes to type 1. This system must not execute until after sys1 is done,
 	// in order to avoid race conditions.
-	auto &sys2 = ecs.make_system<manual_update>([](type<1> &) {
+	auto &sys2 = rt.make_system<manual_update>([](type<1> &) {
 		std::cout << "2 ";
 		std::this_thread::sleep_for(20ms);
 	});
@@ -44,7 +44,7 @@ int main() {
 	//
 	// Writes to type 2. This has no dependencies on type 0 or 1, so it can be run
 	// concurrently with sys1 and sys2.
-	auto &sys3 = ecs.make_system<manual_update>([](type<2> &) {
+	auto &sys3 = rt.make_system<manual_update>([](type<2> &) {
 		std::cout << "3 ";
 		std::this_thread::sleep_for(20ms);
 	});
@@ -54,7 +54,7 @@ int main() {
 
 	//
 	// Reads from type 0. Must not execute until sys1 is done.
-	auto &sys4 = ecs.make_system<manual_update>([](type<0> const &) {
+	auto &sys4 = rt.make_system<manual_update>([](type<0> const &) {
 		std::cout << "4 ";
 		std::this_thread::sleep_for(20ms);
 	});
@@ -66,7 +66,7 @@ int main() {
 	//
 	// Writes to type 2 and reads from type 0. Must not execute until after
 	// sys3 and sys1 us done.
-	auto &sys5 = ecs.make_system<manual_update>([](type<2> &, type<0> const &) {
+	auto &sys5 = rt.make_system<manual_update>([](type<2> &, type<0> const &) {
 		std::cout << "5 ";
 		std::this_thread::sleep_for(20ms);
 	});
@@ -78,7 +78,7 @@ int main() {
 
 	//
 	// Reads from type 2. Must not execute until sys5 is done.
-	auto &sys6 = ecs.make_system<manual_update>([](type<2> const &) {
+	auto &sys6 = rt.make_system<manual_update>([](type<2> const &) {
 		std::cout << "6 ";
 		std::this_thread::sleep_for(20ms);
 	});
@@ -92,7 +92,7 @@ int main() {
 	//
 	// Add the components to an entitiy and run the systems.
 	std::cout << "\nrunning systems on 5 entities:\n";
-	ecs.add_component({0, 4}, type<0>{}, type<1>{}, type<2>{});
-	ecs.update();
+	rt.add_component({0, 4}, type<0>{}, type<1>{}, type<2>{});
+	rt.update();
 	std::cout << '\n';
 }

--- a/examples/sorting/sorting.cpp
+++ b/examples/sorting/sorting.cpp
@@ -18,17 +18,17 @@ bool sort_even_odd(int const& l, int const& r) {
 }
 
 int main() {
-	ecs::runtime ecs;
+	ecs::runtime rt;
 
 	using namespace ecs::opts;
 
-	auto& sys_no_sort = ecs.make_system<not_parallel, manual_update>(printer);
-	auto& sys_sort_asc = ecs.make_system<not_parallel, manual_update>(printer, std::less<int>{});
-	auto& sys_sort_des = ecs.make_system<not_parallel, manual_update>(printer, std::greater<int>{});
-	auto& sys_sort_eo = ecs.make_system<not_parallel, manual_update>(printer, sort_even_odd);
+	auto& sys_no_sort = rt.make_system<not_parallel, manual_update>(printer);
+	auto& sys_sort_asc = rt.make_system<not_parallel, manual_update>(printer, std::less<int>{});
+	auto& sys_sort_des = rt.make_system<not_parallel, manual_update>(printer, std::greater<int>{});
+	auto& sys_sort_eo = rt.make_system<not_parallel, manual_update>(printer, sort_even_odd);
 
-	ecs.add_component_generator({0, 9}, generator);
-	ecs.commit_changes();
+	rt.add_component_generator({0, 9}, generator);
+	rt.commit_changes();
 
 	std::cout << "Unsorted:   ";
 	sys_no_sort.run();

--- a/examples/tagged_components/tagged_components.cpp
+++ b/examples/tagged_components/tagged_components.cpp
@@ -15,23 +15,23 @@ struct shockable_t {
 struct Name : std::string {};
 
 int main() {
-	ecs::runtime ecs;
+	ecs::runtime rt;
 
 	// Add systems for each tag. Will just print the name.
 	// Since tags never hold any data, they are always passed by value
-	ecs.make_system<ecs::opts::group<0>>([](Name const &name, freezeable_t) { std::cout << "  freezeable: " << name << "\n"; });
-	ecs.make_system<ecs::opts::group<1>>([](Name const &name, shockable_t) { std::cout << "  shockable:  " << name << "\n"; });
-	ecs.make_system<ecs::opts::group<2>>([](Name const &name, flameable_t) { std::cout << "  flammeable: " << name << "\n"; });
+	rt.make_system<ecs::opts::group<0>>([](Name const &name, freezeable_t) { std::cout << "  freezeable: " << name << "\n"; });
+	rt.make_system<ecs::opts::group<1>>([](Name const &name, shockable_t) { std::cout << "  shockable:  " << name << "\n"; });
+	rt.make_system<ecs::opts::group<2>>([](Name const &name, flameable_t) { std::cout << "  flammeable: " << name << "\n"; });
 
 	// Set up the entities with a name and tags
-	ecs.add_component(0, Name{"Jon"}, freezeable_t{});
-	ecs.add_component(1, Name{"Sean"}, flameable_t{});
-	ecs.add_component(2, Name{"Jimmy"}, shockable_t{});
-	ecs.add_component(3, Name{"Rachel"}, flameable_t{}, freezeable_t{}, shockable_t{});
-	ecs.add_component(4, Name{"Suzy"}, flameable_t{});
+	rt.add_component(0, Name{"Jon"}, freezeable_t{});
+	rt.add_component(1, Name{"Sean"}, flameable_t{});
+	rt.add_component(2, Name{"Jimmy"}, shockable_t{});
+	rt.add_component(3, Name{"Rachel"}, flameable_t{}, freezeable_t{}, shockable_t{});
+	rt.add_component(4, Name{"Suzy"}, flameable_t{});
 
 	// Commit the changes
-	ecs.commit_changes();
+	rt.commit_changes();
 	std::cout << "Created 'Jon' with freezeable_t\n"
 				 "        'Sean' with flameable_t\n"
 				 "        'Jimmy' with shockable_t\n"
@@ -40,13 +40,13 @@ int main() {
 
 	// Run the systems
 	std::cout << "Running systems:\n";
-	ecs.run_systems();
+	rt.run_systems();
 
 	std::cout << "\nStat dump:\n";
-	std::cout << "  Number of entities with the flameable_t tag:  " << ecs.get_entity_count<flameable_t>()
-			  << "\n  Number of entities with the shockable_t tag:  " << ecs.get_entity_count<shockable_t>()
-			  << "\n  Number of entities with the freezeable_t tag: " << ecs.get_entity_count<freezeable_t>()
-			  << "\n  Number of flameable_t components allocated:   " << ecs.get_component_count<flameable_t>()
-			  << "\n  Number of shockable_t components allocated:   " << ecs.get_component_count<shockable_t>()
-			  << "\n  Number of freezeable_t components allocated:  " << ecs.get_component_count<freezeable_t>() << "\n";
+	std::cout << "  Number of entities with the flameable_t tag:  " << rt.get_entity_count<flameable_t>()
+			  << "\n  Number of entities with the shockable_t tag:  " << rt.get_entity_count<shockable_t>()
+			  << "\n  Number of entities with the freezeable_t tag: " << rt.get_entity_count<freezeable_t>()
+			  << "\n  Number of flameable_t components allocated:   " << rt.get_component_count<flameable_t>()
+			  << "\n  Number of shockable_t components allocated:   " << rt.get_component_count<shockable_t>()
+			  << "\n  Number of freezeable_t components allocated:  " << rt.get_component_count<freezeable_t>() << "\n";
 }


### PR DESCRIPTION
it was confusing (`ecs.` vs `ecs::`), is now changed to `rt.`