### PR TITLE
Disable terminate in contract violations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,14 @@ if (ECS_COMPILE_AS_MODULE)
 	add_library(ecs)
 	target_compile_definitions(ecs PUBLIC ECS_USE_MODULES)
 	target_sources(ecs PUBLIC FILE_SET CXX_MODULES FILES "include/ecs/ecs.ixx")
+
+	if (ECS_ENABLE_CONTRACTS)
+		target_compile_definitions(ecs PUBLIC ECS_ENABLE_CONTRACTS)
+
+		if (ECS_ENABLE_CONTRACTS_AUDIT)
+			target_compile_definitions(ecs PUBLIC ECS_ENABLE_CONTRACTS_AUDIT)
+		endif ()
+	endif ()
 else()
 	# creates a library 'ecs' which is an interface (header files only)
 	add_library(ecs INTERFACE)
@@ -28,15 +36,15 @@ else()
 	)
 
 	target_compile_definitions(ecs INTERFACE ECS_EXPORT=)
-endif()
 
-if (ECS_ENABLE_CONTRACTS)
-	target_compile_definitions(ecs INTERFACE ECS_ENABLE_CONTRACTS)
+	if (ECS_ENABLE_CONTRACTS)
+		target_compile_definitions(ecs INTERFACE ECS_ENABLE_CONTRACTS)
 
-	if (ECS_ENABLE_CONTRACTS_AUDIT)
-		target_compile_definitions(ecs INTERFACE ECS_ENABLE_CONTRACTS_AUDIT)
+		if (ECS_ENABLE_CONTRACTS_AUDIT)
+			target_compile_definitions(ecs INTERFACE ECS_ENABLE_CONTRACTS_AUDIT)
+		endif ()
 	endif ()
-endif ()
+endif()
 
 # determine whether this is a standalone project or included by other projects
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/examples/custom_contract_violation_handler/custom_contract_violation_handler.cpp
+++ b/examples/custom_contract_violation_handler/custom_contract_violation_handler.cpp
@@ -1,35 +1,34 @@
-#include <ecs/detail/contract.h>
+#include <ecs/ecs.h>
 #include <iostream>
 
 // An example handler for contract violations. Dumps input to std::cout.
-// std::terminate() is always called right after these functions complete.
 // All 3 functions shown below must be present in custom handlers.
 struct example_handler {
 	void assertion_failed(char const* sz, char const* msg) {
 		std::cout << "assert (" << sz << "): " << msg << '\n';
+		std::terminate();
 	}
 
 	void precondition_violation(char const* sz, char const* msg) {
 		std::cout << "precondition (" << sz << "): " << msg << '\n';
+		std::terminate();
 	}
 
 	void postcondition_violation(char const* sz, char const* msg) {
 		std::cout << "postcondition (" << sz << "): " << msg << '\n';
+		std::terminate();
 	}
 };
 
 // Override the default handler for contract violations.
 // Comment this out to use the default handler.
-template <> auto contract_violation_handler<> = example_handler{};
+template <> auto ecs::contract_violation_handler<> = example_handler{};
 
 
 int main() {
-	// trigger assert
-	Assert(false, "test assert");
-
-	// trigger pre-condition
-	Pre(false, "test precondition");
-
-	// trigger post-condition
-	Post(false, "test postcondition");
+	// trigger a pre-condition
+	ecs::runtime rt;
+	rt.add_component(0, 0);
+	rt.add_component(0, 0);
+	rt.commit_changes();
 }

--- a/include/ecs/detail/component_pool.h
+++ b/include/ecs/detail/component_pool.h
@@ -617,8 +617,7 @@ private:
 
 				if (curr->range.overlaps(r)) {
 					// Delayed pre-condition check: Can not add components more than once to same entity
-					// Checked in runtime.h
-					//Pre(!curr->active.overlaps(r), "entity already has a component of the type");
+					Pre(!curr->active.overlaps(r), "entity already has a component of the type");
 
 					if (!curr->active.overlaps(r)) {
 						// The incoming range overlaps an unused area in the current chunk

--- a/include/ecs/detail/component_pool.h
+++ b/include/ecs/detail/component_pool.h
@@ -181,8 +181,9 @@ public:
 	// Pre: entities has not already been added, or is in queue to be added
 	//      This condition will not be checked until 'process_changes' is called.
 	// Pre: range and span must be same size.
-	void add_span(entity_range const range, std::span<const T> span) noexcept requires(!detail::unbound<T>) {
-		Pre(range.count() == std::ssize(span), "range and span must be same size");
+	void add_span(entity_range const range, std::span<const T> span) requires(!detail::unbound<T>) {
+		// Check in runtime.h
+		//Pre(range.count() == std::ssize(span), "range and span must be same size");
 
 		// Add the range and function to a temp storage
 		deferred_spans.local().emplace_back(range, span);
@@ -602,7 +603,8 @@ private:
 
 				if (curr->range.overlaps(r)) {
 					// Delayed pre-condition check: Can not add components more than once to same entity
-					Pre(!curr->active.overlaps(r), "entity already has a component of the type");
+					// Checked in runtime.h
+					//Pre(!curr->active.overlaps(r), "entity already has a component of the type");
 
 					// Incoming range overlaps the current one, so add it into 'curr'
 					fill_data_in_existing_chunk(curr, r);

--- a/include/ecs/detail/component_pool.h
+++ b/include/ecs/detail/component_pool.h
@@ -170,6 +170,10 @@ public:
 			chunks.clear();
 		} else {
 			free_all_chunks();
+			deferred_adds.clear();
+			deferred_spans.clear();
+			deferred_gen.clear();
+			deferred_removes.clear();
 		}
 	}
 
@@ -276,7 +280,7 @@ public:
 
 	// Merge all the components queued for addition to the main storage,
 	// and remove components queued for removal
-	void process_changes() noexcept override {
+	void process_changes() override {
 		if constexpr (!global<T>) {
 			process_remove_components();
 			process_add_components();
@@ -573,7 +577,7 @@ private:
 	}
 
 	template <typename U>
-	void process_add_components(std::vector<U> const& vec) noexcept {
+	void process_add_components(std::vector<U> const& vec) {
 		if (vec.empty()) {
 			return;
 		}
@@ -620,7 +624,7 @@ private:
 	}
 
 	// Add new queued entities and components to the main storage.
-	void process_add_components() noexcept {
+	void process_add_components() {
 		auto const adder = [this]<typename C>(std::vector<C>& vec) {
 			if (vec.empty())
 				return;

--- a/include/ecs/detail/contract.h
+++ b/include/ecs/detail/contract.h
@@ -22,8 +22,9 @@ struct default_contract_violation_impl {
 		std::cerr << why << ": \"" << how << "\"\n\t" << what << "\n\n";
 #ifdef __cpp_lib_stacktrace
 		// Dump a stack trace if available
-		std::cerr << "** Stackdump **\n" << std::stacktrace::current(3) << '\n';
+		std::cerr << "** stack dump **\n" << std::stacktrace::current(3) << '\n';
 #endif
+		std::terminate();
 	}
 
 	void assertion_failed(char const* what, char const* how) noexcept {
@@ -51,7 +52,6 @@ template <typename... DummyArgs>
 inline void do_assertion_failed(char const* what, char const* how) noexcept {
 	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
 	cvi.assertion_failed(what, how);
-	std::terminate();
 }
 
 template <typename... DummyArgs>
@@ -59,7 +59,6 @@ template <typename... DummyArgs>
 inline void do_precondition_violation(char const* what, char const* how) noexcept {
 	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
 	cvi.precondition_violation(what, how);
-	std::terminate();
 }
 
 template <typename... DummyArgs>
@@ -67,7 +66,6 @@ template <typename... DummyArgs>
 inline void do_postcondition_violation(char const* what, char const* how) noexcept {
 	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
 	cvi.postcondition_violation(what, how);
-	std::terminate();
 }
 } // namespace ecs::detail
 

--- a/include/ecs/detail/contract.h
+++ b/include/ecs/detail/contract.h
@@ -42,9 +42,10 @@ struct default_contract_violation_impl {
 } // namespace ecs::detail
 
 // The contract violation interface, which can be overridden by users
-
+ECS_EXPORT namespace ecs {
 template <typename...>
-inline auto contract_violation_handler = ecs::detail::default_contract_violation_impl{};
+auto contract_violation_handler = ecs::detail::default_contract_violation_impl{};
+}
 
 #if defined(ECS_ENABLE_CONTRACTS)
 
@@ -52,21 +53,21 @@ namespace ecs::detail {
 template <typename... DummyArgs>
 	requires(sizeof...(DummyArgs) == 0)
 inline void do_assertion_failed(char const* what, char const* how) {
-	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
+	ecs::detail::contract_violation_interface auto& cvi = ecs::contract_violation_handler<DummyArgs...>;
 	cvi.assertion_failed(what, how);
 }
 
 template <typename... DummyArgs>
 	requires(sizeof...(DummyArgs) == 0)
 inline void do_precondition_violation(char const* what, char const* how) {
-	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
+	ecs::detail::contract_violation_interface auto& cvi = ecs::contract_violation_handler<DummyArgs...>;
 	cvi.precondition_violation(what, how);
 }
 
 template <typename... DummyArgs>
 	requires(sizeof...(DummyArgs) == 0)
 inline void do_postcondition_violation(char const* what, char const* how) {
-	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
+	ecs::detail::contract_violation_interface auto& cvi = ecs::contract_violation_handler<DummyArgs...>;
 	cvi.postcondition_violation(what, how);
 }
 } // namespace ecs::detail

--- a/include/ecs/detail/contract.h
+++ b/include/ecs/detail/contract.h
@@ -46,30 +46,31 @@ struct default_contract_violation_impl {
 template <typename...>
 inline auto contract_violation_handler = ecs::detail::default_contract_violation_impl{};
 
+#if defined(ECS_ENABLE_CONTRACTS)
+
 namespace ecs::detail {
 template <typename... DummyArgs>
 	requires(sizeof...(DummyArgs) == 0)
-inline void do_assertion_failed(char const* what, char const* how) noexcept {
+inline void do_assertion_failed(char const* what, char const* how) {
 	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
 	cvi.assertion_failed(what, how);
 }
 
 template <typename... DummyArgs>
 	requires(sizeof...(DummyArgs) == 0)
-inline void do_precondition_violation(char const* what, char const* how) noexcept {
+inline void do_precondition_violation(char const* what, char const* how) {
 	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
 	cvi.precondition_violation(what, how);
 }
 
 template <typename... DummyArgs>
 	requires(sizeof...(DummyArgs) == 0)
-inline void do_postcondition_violation(char const* what, char const* how) noexcept {
+inline void do_postcondition_violation(char const* what, char const* how) {
 	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
 	cvi.postcondition_violation(what, how);
 }
 } // namespace ecs::detail
 
-#if defined(ECS_ENABLE_CONTRACTS)
 
 #define Assert(expression, message)                                                                                                        \
 	do {                                                                                                                                   \

--- a/include/ecs/ecs.ixx
+++ b/include/ecs/ecs.ixx
@@ -906,8 +906,9 @@ struct default_contract_violation_impl {
 		std::cerr << why << ": \"" << how << "\"\n\t" << what << "\n\n";
 #ifdef __cpp_lib_stacktrace
 		// Dump a stack trace if available
-		std::cerr << "** Stackdump **\n" << std::stacktrace::current(3) << '\n';
+		std::cerr << "** stack dump **\n" << std::stacktrace::current(3) << '\n';
 #endif
+		std::terminate();
 	}
 
 	void assertion_failed(char const* what, char const* how) noexcept {
@@ -925,37 +926,36 @@ struct default_contract_violation_impl {
 } // namespace ecs::detail
 
 // The contract violation interface, which can be overridden by users
-
+ECS_EXPORT namespace ecs {
 template <typename...>
-inline auto contract_violation_handler = ecs::detail::default_contract_violation_impl{};
+auto contract_violation_handler = ecs::detail::default_contract_violation_impl{};
+}
+
+#if defined(ECS_ENABLE_CONTRACTS)
 
 namespace ecs::detail {
 template <typename... DummyArgs>
 	requires(sizeof...(DummyArgs) == 0)
-inline void do_assertion_failed(char const* what, char const* how) noexcept {
-	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
+inline void do_assertion_failed(char const* what, char const* how) {
+	ecs::detail::contract_violation_interface auto& cvi = ecs::contract_violation_handler<DummyArgs...>;
 	cvi.assertion_failed(what, how);
-	std::terminate();
 }
 
 template <typename... DummyArgs>
 	requires(sizeof...(DummyArgs) == 0)
-inline void do_precondition_violation(char const* what, char const* how) noexcept {
-	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
+inline void do_precondition_violation(char const* what, char const* how) {
+	ecs::detail::contract_violation_interface auto& cvi = ecs::contract_violation_handler<DummyArgs...>;
 	cvi.precondition_violation(what, how);
-	std::terminate();
 }
 
 template <typename... DummyArgs>
 	requires(sizeof...(DummyArgs) == 0)
-inline void do_postcondition_violation(char const* what, char const* how) noexcept {
-	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
+inline void do_postcondition_violation(char const* what, char const* how) {
+	ecs::detail::contract_violation_interface auto& cvi = ecs::contract_violation_handler<DummyArgs...>;
 	cvi.postcondition_violation(what, how);
-	std::terminate();
 }
 } // namespace ecs::detail
 
-#if defined(ECS_ENABLE_CONTRACTS)
 
 #define Assert(expression, message)                                                                                                        \
 	do {                                                                                                                                   \
@@ -1507,12 +1507,14 @@ public:
 
 		// Remove from the front
 		if (other.first() == range.first()) {
-			return {entity_range{other.last() + 1, range.last()}, std::nullopt};
+			auto const [min, max] = std::minmax(range.last(), other.last());
+			return {entity_range{min + 1, max}, std::nullopt};
 		}
 
 		// Remove from the back
 		if (other.last() == range.last()) {
-			return {entity_range{range.first(), other.first() - 1}, std::nullopt};
+			auto const [min, max] = std::minmax(range.first(), other.first());
+			return {entity_range{min, max - 1}, std::nullopt};
 		}
 
 		if (range.contains(other)) {
@@ -1887,6 +1889,10 @@ public:
 			chunks.clear();
 		} else {
 			free_all_chunks();
+			deferred_adds.clear();
+			deferred_spans.clear();
+			deferred_gen.clear();
+			deferred_removes.clear();
 		}
 	}
 
@@ -1894,8 +1900,9 @@ public:
 	// Pre: entities has not already been added, or is in queue to be added
 	//      This condition will not be checked until 'process_changes' is called.
 	// Pre: range and span must be same size.
-	void add_span(entity_range const range, std::span<const T> span) noexcept requires(!detail::unbound<T>) {
-		Pre(range.count() == std::ssize(span), "range and span must be same size");
+	void add_span(entity_range const range, std::span<const T> span) requires(!detail::unbound<T>) {
+		// Check in runtime.h
+		//Pre(range.count() == std::ssize(span), "range and span must be same size");
 
 		// Add the range and function to a temp storage
 		deferred_spans.local().emplace_back(range, span);
@@ -1993,7 +2000,7 @@ public:
 
 	// Merge all the components queued for addition to the main storage,
 	// and remove components queued for removal
-	void process_changes() noexcept override {
+	void process_changes() override {
 		if constexpr (!global<T>) {
 			process_remove_components();
 			process_add_components();
@@ -2068,13 +2075,26 @@ public:
 	}
 
 	// Returns true if an entity range has components in this pool
-	bool has_entity(entity_range const& range) const noexcept {
-		auto const it = find_in_ordered_active_ranges(range);
+	bool has_entity(entity_range range) const noexcept {
+		auto it = find_in_ordered_active_ranges(range);
+		while (it != chunks.end()) {
+			if (it->range.first() > range.last())
+				return false;
 
-		if (it == chunks.end())
-			return false;
+			if (it->active.contains(range))
+				return true;
 
-		return it->active.contains(range);
+			if (it->active.overlaps(range)) {
+				auto const [r, m] = entity_range::remove(range, it->active);
+				if (m)
+					return false;
+				range = r;
+			}
+
+			std::advance(it, 1);
+		}
+
+		return false;
 	}
 
 	// Clear all entities from the pool
@@ -2103,6 +2123,7 @@ public:
 private:
 	chunk_iter create_new_chunk(chunk_iter it_loc, entity_range const range, entity_range const active, T* data = nullptr,
 								bool owns_data = true, bool split_data = false) noexcept {
+		Pre(range.contains(active), "active range is not contained in the total range");
 		return chunks.emplace(it_loc, range, active, data, owns_data, split_data);
 	}
 
@@ -2226,7 +2247,7 @@ private:
 			}
 		}
 
-		if (curr->active.adjacent(r)) {
+		if (curr->active.adjacent(r) && curr->range.contains(r)) {
 			// The two ranges are next to each other, so add the data to existing chunk
 			entity_range active_range = entity_range::merge(curr->active, r);
 			curr->active = active_range;
@@ -2290,7 +2311,7 @@ private:
 	}
 
 	template <typename U>
-	void process_add_components(std::vector<U> const& vec) noexcept {
+	void process_add_components(std::vector<U>& vec) {
 		if (vec.empty()) {
 			return;
 		}
@@ -2317,10 +2338,28 @@ private:
 					// Delayed pre-condition check: Can not add components more than once to same entity
 					Pre(!curr->active.overlaps(r), "entity already has a component of the type");
 
-					// Incoming range overlaps the current one, so add it into 'curr'
-					fill_data_in_existing_chunk(curr, r);
-					if constexpr (!unbound<T>) {
-						construct_range_in_chunk(curr, r, iter->data);
+					if (!curr->active.overlaps(r)) {
+						// The incoming range overlaps an unused area in the current chunk
+
+						// split the current chunk and fill in the data
+						entity_range const active_range = entity_range::intersect(curr->range, r);
+						fill_data_in_existing_chunk(curr, active_range);
+						if constexpr (!unbound<T>) {
+							construct_range_in_chunk(curr, active_range, iter->data);
+						}
+
+						if (active_range != r) {
+							auto const [remainder, x] = entity_range::remove(active_range, r);
+							Assert(!x.has_value(), "internal: there should not be a range here; create an issue on Github and investigate");
+							iter->rng = remainder;
+							continue;
+						}
+					} else {
+						// Incoming range overlaps the current one, so add it into 'curr'
+						fill_data_in_existing_chunk(curr, r);
+						if constexpr (!unbound<T>) {
+							construct_range_in_chunk(curr, r, iter->data);
+						}
 					}
 				} else if (curr->range < r) {
 					// Incoming range is larger than the current one, so add it after 'curr'
@@ -2337,7 +2376,7 @@ private:
 	}
 
 	// Add new queued entities and components to the main storage.
-	void process_add_components() noexcept {
+	void process_add_components() {
 		auto const adder = [this]<typename C>(std::vector<C>& vec) {
 			if (vec.empty())
 				return;
@@ -4350,20 +4389,20 @@ public:
 			// Add it to the component pool
 			if constexpr (detail::is_parent<Type>::value) {
 				detail::component_pool<detail::parent_id>& pool = ctx.get_component_pool<detail::parent_id>();
-				PreAudit(!pool.has_entity(range), "one- or more entities in the range already has this type");
+				Pre(!pool.has_entity(range), "one- or more entities in the range already has this type");
 				pool.add(range, detail::parent_id{val.id()});
 			} else if constexpr (std::is_reference_v<Type>) {
 				using DerefT = std::remove_cvref_t<Type>;
 				static_assert(std::copyable<DerefT>, "Type must be copyable");
 
 				detail::component_pool<DerefT>& pool = ctx.get_component_pool<DerefT>();
-				PreAudit(!pool.has_entity(range), "one- or more entities in the range already has this type");
+				Pre(!pool.has_entity(range), "one- or more entities in the range already has this type");
 				pool.add(range, val);
 			} else {
 				static_assert(std::copyable<Type>, "Type must be copyable");
 
 				detail::component_pool<Type>& pool = ctx.get_component_pool<Type>();
-				PreAudit(!pool.has_entity(range), "one- or more entities in the range already has this type");
+				Pre(!pool.has_entity(range), "one- or more entities in the range already has this type");
 				pool.add(range, std::forward<Type>(val));
 			}
 		};

--- a/include/ecs/ecs_sh.h
+++ b/include/ecs/ecs_sh.h
@@ -907,8 +907,9 @@ struct default_contract_violation_impl {
 		std::cerr << why << ": \"" << how << "\"\n\t" << what << "\n\n";
 #ifdef __cpp_lib_stacktrace
 		// Dump a stack trace if available
-		std::cerr << "** Stackdump **\n" << std::stacktrace::current(3) << '\n';
+		std::cerr << "** stack dump **\n" << std::stacktrace::current(3) << '\n';
 #endif
+		std::terminate();
 	}
 
 	void assertion_failed(char const* what, char const* how) noexcept {
@@ -926,37 +927,36 @@ struct default_contract_violation_impl {
 } // namespace ecs::detail
 
 // The contract violation interface, which can be overridden by users
-
+ECS_EXPORT namespace ecs {
 template <typename...>
-inline auto contract_violation_handler = ecs::detail::default_contract_violation_impl{};
+auto contract_violation_handler = ecs::detail::default_contract_violation_impl{};
+}
+
+#if defined(ECS_ENABLE_CONTRACTS)
 
 namespace ecs::detail {
 template <typename... DummyArgs>
 	requires(sizeof...(DummyArgs) == 0)
-inline void do_assertion_failed(char const* what, char const* how) noexcept {
-	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
+inline void do_assertion_failed(char const* what, char const* how) {
+	ecs::detail::contract_violation_interface auto& cvi = ecs::contract_violation_handler<DummyArgs...>;
 	cvi.assertion_failed(what, how);
-	std::terminate();
 }
 
 template <typename... DummyArgs>
 	requires(sizeof...(DummyArgs) == 0)
-inline void do_precondition_violation(char const* what, char const* how) noexcept {
-	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
+inline void do_precondition_violation(char const* what, char const* how) {
+	ecs::detail::contract_violation_interface auto& cvi = ecs::contract_violation_handler<DummyArgs...>;
 	cvi.precondition_violation(what, how);
-	std::terminate();
 }
 
 template <typename... DummyArgs>
 	requires(sizeof...(DummyArgs) == 0)
-inline void do_postcondition_violation(char const* what, char const* how) noexcept {
-	ecs::detail::contract_violation_interface auto& cvi = contract_violation_handler<DummyArgs...>;
+inline void do_postcondition_violation(char const* what, char const* how) {
+	ecs::detail::contract_violation_interface auto& cvi = ecs::contract_violation_handler<DummyArgs...>;
 	cvi.postcondition_violation(what, how);
-	std::terminate();
 }
 } // namespace ecs::detail
 
-#if defined(ECS_ENABLE_CONTRACTS)
 
 #define Assert(expression, message)                                                                                                        \
 	do {                                                                                                                                   \
@@ -1508,12 +1508,14 @@ public:
 
 		// Remove from the front
 		if (other.first() == range.first()) {
-			return {entity_range{other.last() + 1, range.last()}, std::nullopt};
+			auto const [min, max] = std::minmax(range.last(), other.last());
+			return {entity_range{min + 1, max}, std::nullopt};
 		}
 
 		// Remove from the back
 		if (other.last() == range.last()) {
-			return {entity_range{range.first(), other.first() - 1}, std::nullopt};
+			auto const [min, max] = std::minmax(range.first(), other.first());
+			return {entity_range{min, max - 1}, std::nullopt};
 		}
 
 		if (range.contains(other)) {
@@ -1888,6 +1890,10 @@ public:
 			chunks.clear();
 		} else {
 			free_all_chunks();
+			deferred_adds.clear();
+			deferred_spans.clear();
+			deferred_gen.clear();
+			deferred_removes.clear();
 		}
 	}
 
@@ -1895,8 +1901,9 @@ public:
 	// Pre: entities has not already been added, or is in queue to be added
 	//      This condition will not be checked until 'process_changes' is called.
 	// Pre: range and span must be same size.
-	void add_span(entity_range const range, std::span<const T> span) noexcept requires(!detail::unbound<T>) {
-		Pre(range.count() == std::ssize(span), "range and span must be same size");
+	void add_span(entity_range const range, std::span<const T> span) requires(!detail::unbound<T>) {
+		// Check in runtime.h
+		//Pre(range.count() == std::ssize(span), "range and span must be same size");
 
 		// Add the range and function to a temp storage
 		deferred_spans.local().emplace_back(range, span);
@@ -1994,7 +2001,7 @@ public:
 
 	// Merge all the components queued for addition to the main storage,
 	// and remove components queued for removal
-	void process_changes() noexcept override {
+	void process_changes() override {
 		if constexpr (!global<T>) {
 			process_remove_components();
 			process_add_components();
@@ -2069,13 +2076,26 @@ public:
 	}
 
 	// Returns true if an entity range has components in this pool
-	bool has_entity(entity_range const& range) const noexcept {
-		auto const it = find_in_ordered_active_ranges(range);
+	bool has_entity(entity_range range) const noexcept {
+		auto it = find_in_ordered_active_ranges(range);
+		while (it != chunks.end()) {
+			if (it->range.first() > range.last())
+				return false;
 
-		if (it == chunks.end())
-			return false;
+			if (it->active.contains(range))
+				return true;
 
-		return it->active.contains(range);
+			if (it->active.overlaps(range)) {
+				auto const [r, m] = entity_range::remove(range, it->active);
+				if (m)
+					return false;
+				range = r;
+			}
+
+			std::advance(it, 1);
+		}
+
+		return false;
 	}
 
 	// Clear all entities from the pool
@@ -2104,6 +2124,7 @@ public:
 private:
 	chunk_iter create_new_chunk(chunk_iter it_loc, entity_range const range, entity_range const active, T* data = nullptr,
 								bool owns_data = true, bool split_data = false) noexcept {
+		Pre(range.contains(active), "active range is not contained in the total range");
 		return chunks.emplace(it_loc, range, active, data, owns_data, split_data);
 	}
 
@@ -2227,7 +2248,7 @@ private:
 			}
 		}
 
-		if (curr->active.adjacent(r)) {
+		if (curr->active.adjacent(r) && curr->range.contains(r)) {
 			// The two ranges are next to each other, so add the data to existing chunk
 			entity_range active_range = entity_range::merge(curr->active, r);
 			curr->active = active_range;
@@ -2291,7 +2312,7 @@ private:
 	}
 
 	template <typename U>
-	void process_add_components(std::vector<U> const& vec) noexcept {
+	void process_add_components(std::vector<U>& vec) {
 		if (vec.empty()) {
 			return;
 		}
@@ -2318,10 +2339,28 @@ private:
 					// Delayed pre-condition check: Can not add components more than once to same entity
 					Pre(!curr->active.overlaps(r), "entity already has a component of the type");
 
-					// Incoming range overlaps the current one, so add it into 'curr'
-					fill_data_in_existing_chunk(curr, r);
-					if constexpr (!unbound<T>) {
-						construct_range_in_chunk(curr, r, iter->data);
+					if (!curr->active.overlaps(r)) {
+						// The incoming range overlaps an unused area in the current chunk
+
+						// split the current chunk and fill in the data
+						entity_range const active_range = entity_range::intersect(curr->range, r);
+						fill_data_in_existing_chunk(curr, active_range);
+						if constexpr (!unbound<T>) {
+							construct_range_in_chunk(curr, active_range, iter->data);
+						}
+
+						if (active_range != r) {
+							auto const [remainder, x] = entity_range::remove(active_range, r);
+							Assert(!x.has_value(), "internal: there should not be a range here; create an issue on Github and investigate");
+							iter->rng = remainder;
+							continue;
+						}
+					} else {
+						// Incoming range overlaps the current one, so add it into 'curr'
+						fill_data_in_existing_chunk(curr, r);
+						if constexpr (!unbound<T>) {
+							construct_range_in_chunk(curr, r, iter->data);
+						}
 					}
 				} else if (curr->range < r) {
 					// Incoming range is larger than the current one, so add it after 'curr'
@@ -2338,7 +2377,7 @@ private:
 	}
 
 	// Add new queued entities and components to the main storage.
-	void process_add_components() noexcept {
+	void process_add_components() {
 		auto const adder = [this]<typename C>(std::vector<C>& vec) {
 			if (vec.empty())
 				return;
@@ -4351,20 +4390,20 @@ public:
 			// Add it to the component pool
 			if constexpr (detail::is_parent<Type>::value) {
 				detail::component_pool<detail::parent_id>& pool = ctx.get_component_pool<detail::parent_id>();
-				PreAudit(!pool.has_entity(range), "one- or more entities in the range already has this type");
+				Pre(!pool.has_entity(range), "one- or more entities in the range already has this type");
 				pool.add(range, detail::parent_id{val.id()});
 			} else if constexpr (std::is_reference_v<Type>) {
 				using DerefT = std::remove_cvref_t<Type>;
 				static_assert(std::copyable<DerefT>, "Type must be copyable");
 
 				detail::component_pool<DerefT>& pool = ctx.get_component_pool<DerefT>();
-				PreAudit(!pool.has_entity(range), "one- or more entities in the range already has this type");
+				Pre(!pool.has_entity(range), "one- or more entities in the range already has this type");
 				pool.add(range, val);
 			} else {
 				static_assert(std::copyable<Type>, "Type must be copyable");
 
 				detail::component_pool<Type>& pool = ctx.get_component_pool<Type>();
-				PreAudit(!pool.has_entity(range), "one- or more entities in the range already has this type");
+				Pre(!pool.has_entity(range), "one- or more entities in the range already has this type");
 				pool.add(range, std::forward<Type>(val));
 			}
 		};

--- a/include/ecs/entity_range.h
+++ b/include/ecs/entity_range.h
@@ -119,12 +119,14 @@ public:
 
 		// Remove from the front
 		if (other.first() == range.first()) {
-			return {entity_range{other.last() + 1, range.last()}, std::nullopt};
+			auto const [min, max] = std::minmax(range.last(), other.last());
+			return {entity_range{min + 1, max}, std::nullopt};
 		}
 
 		// Remove from the back
 		if (other.last() == range.last()) {
-			return {entity_range{range.first(), other.first() - 1}, std::nullopt};
+			auto const [min, max] = std::minmax(range.first(), other.first());
+			return {entity_range{min, max - 1}, std::nullopt};
 		}
 
 		if (range.contains(other)) {

--- a/include/ecs/runtime.h
+++ b/include/ecs/runtime.h
@@ -30,20 +30,20 @@ public:
 			// Add it to the component pool
 			if constexpr (detail::is_parent<Type>::value) {
 				detail::component_pool<detail::parent_id>& pool = ctx.get_component_pool<detail::parent_id>();
-				PreAudit(!pool.has_entity(range), "one- or more entities in the range already has this type");
+				Pre(!pool.has_entity(range), "one- or more entities in the range already has this type");
 				pool.add(range, detail::parent_id{val.id()});
 			} else if constexpr (std::is_reference_v<Type>) {
 				using DerefT = std::remove_cvref_t<Type>;
 				static_assert(std::copyable<DerefT>, "Type must be copyable");
 
 				detail::component_pool<DerefT>& pool = ctx.get_component_pool<DerefT>();
-				PreAudit(!pool.has_entity(range), "one- or more entities in the range already has this type");
+				Pre(!pool.has_entity(range), "one- or more entities in the range already has this type");
 				pool.add(range, val);
 			} else {
 				static_assert(std::copyable<Type>, "Type must be copyable");
 
 				detail::component_pool<Type>& pool = ctx.get_component_pool<Type>();
-				PreAudit(!pool.has_entity(range), "one- or more entities in the range already has this type");
+				Pre(!pool.has_entity(range), "one- or more entities in the range already has this type");
 				pool.add(range, std::forward<Type>(val));
 			}
 		};

--- a/presets.msvc.json
+++ b/presets.msvc.json
@@ -10,7 +10,7 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "ECS_COMPILE_AS_MODULE": false,
         "ECS_ENABLE_CONTRACTS": true,
-        "ECS_ENABLE_CONTRACTS_AUDIT": true
+        "ECS_ENABLE_CONTRACTS_AUDIT": false
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -48,8 +48,7 @@
       "inherts": "windows-base",
       "displayName": "Release",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "ECS_ENABLE_CONTRACTS": false
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
@@ -58,8 +57,7 @@
       "displayName": "Release/Module",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "ECS_COMPILE_AS_MODULE": true,
-        "ECS_ENABLE_CONTRACTS": false
+        "ECS_COMPILE_AS_MODULE": true
       }
     },
     {

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -1,5 +1,7 @@
 ﻿cmake_minimum_required (VERSION 3.15)
 
+set(ECS_ENABLE_CONTRACTS ON)
+
 macro(make_test)
 	add_executable (${ARGV0} ${ARGV1})
 	target_link_libraries(${ARGV0} ecs)

--- a/unittest/component_flags.cpp
+++ b/unittest/component_flags.cpp
@@ -1,4 +1,4 @@
-#include <ecs/runtime.h>
+#include <ecs/ecs_sh.h>
 
 struct test_tag {
 	using ecs_flags = ecs::flags<ecs::tag>;

--- a/unittest/component_pool.cpp
+++ b/unittest/component_pool.cpp
@@ -6,11 +6,11 @@
 
 // Override the default handler for contract violations.
 struct unittest_handler {
-	void assertion_failed(char const* , char const* msg)        { throw std::exception(msg); }
-	void precondition_violation(char const* , char const* msg)  { throw std::exception(msg); }
-	void postcondition_violation(char const* , char const* msg) { throw std::exception(msg); }
+	void assertion_failed(char const* , char const* msg)        { throw std::runtime_error(msg); }
+	void precondition_violation(char const* , char const* msg)  { throw std::runtime_error(msg); }
+	void postcondition_violation(char const* , char const* msg) { throw std::runtime_error(msg); }
 };
-template <> auto contract_violation_handler<> = unittest_handler{};
+template <> auto ecs::contract_violation_handler<> = unittest_handler{};
 
 
 // A helper class that counts invocations of constructers/destructor

--- a/unittest/component_pool.cpp
+++ b/unittest/component_pool.cpp
@@ -1,8 +1,19 @@
 #include <ecs/ecs.h>
+#include <exception>
 #include <numeric>
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
+// Override the default handler for contract violations.
+struct unittest_handler {
+	void assertion_failed(char const* , char const* msg)        { throw std::exception(msg); }
+	void precondition_violation(char const* , char const* msg)  { throw std::exception(msg); }
+	void postcondition_violation(char const* , char const* msg) { throw std::exception(msg); }
+};
+template <> auto contract_violation_handler<> = unittest_handler{};
+
+
+// A helper class that counts invocations of constructers/destructor
 struct ctr_counter {
 	inline static size_t def_ctr_count = 0;
 	inline static size_t ctr_count = 0;
@@ -14,7 +25,7 @@ struct ctr_counter {
 		def_ctr_count++;
 		ctr_count++;
 	}
-	ctr_counter(ctr_counter const& /*other*/) {
+	ctr_counter(ctr_counter const& /*other*/) noexcept {
 		copy_count++;
 		ctr_count++;
 	}
@@ -22,7 +33,7 @@ struct ctr_counter {
 		move_count++;
 		ctr_count++;
 	}
-	~ctr_counter() {
+	~ctr_counter() noexcept {
 		dtr_count++;
 	}
 
@@ -56,7 +67,7 @@ TEST_CASE("Component pool specification", "[component]") {
 	}
 
 	SECTION("Adding components") {
-		SECTION("does not perform unneccesary copies of components") {
+		SECTION("does not perform copies of components") {
 			ecs::detail::component_pool<ctr_counter> pool;
 			pool.add({0, 2}, ctr_counter{});
 			pool.process_changes();
@@ -101,6 +112,43 @@ TEST_CASE("Component pool specification", "[component]") {
 
 			REQUIRE(50 == pool.num_components());
 			REQUIRE(50 == pool.num_entities());
+		}
+		SECTION("has_entity works correctly") {
+			ecs::detail::component_pool<int> pool;
+			pool.add({0, 10}, 0);
+			pool.process_changes();
+
+			pool.remove({1, 10});
+			pool.process_changes();
+
+			pool.add({8, 15}, 1);
+			pool.process_changes();
+		}
+	}
+
+	SECTION("Testing components") {
+		SECTION("stradling ranges works") {
+			ecs::detail::component_pool<int> pool;
+			pool.add({0, 10}, 0);
+			pool.process_changes();
+			pool.add({11, 20}, 0);
+			pool.process_changes();
+
+			CHECK(2 == pool.num_chunks());
+			REQUIRE(pool.has_entity({5, 15}));
+		}
+
+		SECTION("stradling ranges with gaps works") {
+			ecs::detail::component_pool<int> pool;
+			pool.add({0, 9}, 0);
+			pool.process_changes();
+			pool.add({11, 20}, 0);
+			pool.process_changes();
+			pool.add({21, 30}, 0);
+			pool.process_changes();
+
+			CHECK(3 == pool.num_chunks());
+			REQUIRE(!pool.has_entity({5, 15})); // entity 10 missing
 		}
 	}
 
@@ -415,6 +463,34 @@ TEST_CASE("Component pool specification", "[component]") {
 			REQUIRE(3 == *pool.find_component_data(3));
 			REQUIRE(4 == *pool.find_component_data(4));
 			REQUIRE(5 == *pool.find_component_data(5));
+		}
+
+		SECTION("overflowing gaps") {
+			ecs::detail::component_pool<int> pool;
+			// active: 0-10
+			pool.add({0, 10}, 0);
+			pool.process_changes();
+
+			// active: 0-0
+			pool.remove({1, 10});
+			pool.process_changes();
+
+			// active: 0-0
+			// active: 8-10
+			// active: 11-15
+			pool.add({8, 15}, 1);
+			pool.process_changes();
+
+			// There should be 3 chunks
+			REQUIRE(3 == pool.num_chunks());
+
+			// Verify the active ranges
+			auto const chunk1 = pool.get_head_chunk();
+			auto const chunk2 = std::next(chunk1);
+			auto const chunk3 = std::next(chunk2);
+			REQUIRE(ecs::entity_range{ 0,  0} == chunk1->active);
+			REQUIRE(ecs::entity_range{ 8, 10} == chunk2->active);
+			REQUIRE(ecs::entity_range{11, 15} == chunk3->active);
 		}
 
 		SECTION("filling gaps in unrelated ranges") {

--- a/unittest/runtime.cpp
+++ b/unittest/runtime.cpp
@@ -1,7 +1,17 @@
 #include <ecs/ecs.h>
+#include <exception>
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
+// Override the default handler for contract violations.
+struct unittest_handler {
+	void assertion_failed(char const* , char const* msg)        { throw std::exception(msg); }
+	void precondition_violation(char const* , char const* msg)  { throw std::exception(msg); }
+	void postcondition_violation(char const* , char const* msg) { throw std::exception(msg); }
+};
+template <> auto contract_violation_handler<> = unittest_handler{};
+
+// A helper class that counts invocations of constructers/destructor
 struct runtime_ctr_counter {
 	inline static int def_ctr_count = 0;
 	inline static int ctr_count = 0;
@@ -106,6 +116,17 @@ TEST_CASE("The runtime interface") {
 				int i = *ecs.get_component<int>(ent);
 				CHECK(i == 42);
 			}
+		}
+
+		SECTION("with a span must be equal in size") {
+			ecs::runtime rt;
+			
+			// 10 ints
+			std::array<int, 10> ints;
+			std::iota(ints.begin(), ints.end(), 0);
+
+			// 7 entities, must throw
+			REQUIRE_THROWS(rt.add_component_span({0, 6}, ints));
 		}
 
 		SECTION("of components with generator works") {

--- a/unittest/runtime.cpp
+++ b/unittest/runtime.cpp
@@ -1,15 +1,16 @@
 #include <ecs/ecs.h>
+#include <numeric>
 #include <exception>
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
 // Override the default handler for contract violations.
 struct unittest_handler {
-	void assertion_failed(char const* , char const* msg)        { throw std::exception(msg); }
-	void precondition_violation(char const* , char const* msg)  { throw std::exception(msg); }
-	void postcondition_violation(char const* , char const* msg) { throw std::exception(msg); }
+	void assertion_failed(char const* , char const* msg)        { throw std::runtime_error(msg); }
+	void precondition_violation(char const* , char const* msg)  { throw std::runtime_error(msg); }
+	void postcondition_violation(char const* , char const* msg) { throw std::runtime_error(msg); }
 };
-template <> auto contract_violation_handler<> = unittest_handler{};
+template <> auto ecs::contract_violation_handler<> = unittest_handler{};
 
 // A helper class that counts invocations of constructers/destructor
 struct runtime_ctr_counter {

--- a/unittest/tagged_pointer.cpp
+++ b/unittest/tagged_pointer.cpp
@@ -1,5 +1,6 @@
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
+#define ECS_EXPORT
 #include <ecs/detail/tagged_pointer.h>
 #include <bit>
 


### PR DESCRIPTION
This makes it easier to verify failure logic in my unittests.